### PR TITLE
Fix LastUpdate When NPI_Update Is Empty

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,3 @@
+language: go
+go:
+  - 1.8

--- a/command/npi-update/main.go
+++ b/command/npi-update/main.go
@@ -21,7 +21,8 @@ func main() {
 		log.Fatal(err)
 	}
 
-	lastDate, err := npidb.LastUpdate(db)
+	u := npidb.DbUpdateKeeper{db}
+	lastDate, err := npidb.LastUpdate(u)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -38,5 +39,8 @@ func main() {
 	}
 
 	fmt.Println("Recording updates")
-	npidb.RecordUpdate(db, endDate)
+	err = npidb.RecordUpdate(u, endDate)
+	if err != nil {
+		log.Fatalf("Failed to record last update in NPI_Update table: %s", err)
+	}
 }

--- a/db.go
+++ b/db.go
@@ -2,17 +2,30 @@ package npidb
 
 import (
 	"database/sql"
-	"fmt"
 	"time"
 )
 
+type UpdateKeeper interface {
+	GetLastUpdate() (time.Time, error)
+	RecordUpdate(time.Time) error
+}
+
+type DbUpdateKeeper struct {
+	DB *sql.DB
+}
+
+func (u DbUpdateKeeper) GetLastUpdate() (lastDate time.Time, err error) {
+	err = u.DB.QueryRow("SELECT TOP 1 end_date FROM NPI_Update ORDER BY end_date DESC").Scan(&lastDate)
+	return
+}
+
 // Get the date of the last weekly update saved to the database
-func LastUpdate(db *sql.DB) (lastDate time.Time, err error) {
-	err = db.QueryRow("SELECT TOP 1 end_date FROM NPI_Update ORDER BY end_date DESC").Scan(&lastDate)
+func LastUpdate(u UpdateKeeper) (lastDate time.Time, err error) {
+	lastDate, err = u.GetLastUpdate()
 	switch {
 	case err == sql.ErrNoRows:
-		fmt.Println("using default date")
 		lastDate = time.Date(2017, time.June, 11, 0, 0, 0, 0, time.UTC)
+		err = nil
 	case err != nil:
 		return
 	default:
@@ -20,6 +33,11 @@ func LastUpdate(db *sql.DB) (lastDate time.Time, err error) {
 	return
 }
 
-func RecordUpdate(db *sql.DB, t time.Time) (sql.Result, error) {
-	return db.Exec("INSERT INTO NPI_Update (end_date) VALUES (?)", t)
+func (u DbUpdateKeeper) RecordUpdate(t time.Time) (err error) {
+	_, err = u.DB.Exec("INSERT INTO NPI_Update (end_date) VALUES (?)", t)
+	return
+}
+
+func RecordUpdate(u UpdateKeeper, t time.Time) error {
+	return u.RecordUpdate(t)
 }

--- a/db_test.go
+++ b/db_test.go
@@ -1,0 +1,66 @@
+package npidb_test
+
+import (
+	"database/sql"
+	"errors"
+	"time"
+
+	. "github.com/cwarden/npidb"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+type queryResult int
+
+const (
+	noRows queryResult = iota
+	queryError
+	validDate
+)
+
+type stubDbUpdater struct {
+	result queryResult
+}
+
+func (u stubDbUpdater) GetLastUpdate() (lastDate time.Time, err error) {
+	switch u.result {
+	case noRows:
+		err = sql.ErrNoRows
+	case queryError:
+		err = errors.New("Query Failed")
+	case validDate:
+		lastDate = time.Date(2010, time.January, 1, 0, 0, 0, 0, time.UTC)
+	}
+	return
+}
+
+func (u stubDbUpdater) RecordUpdate(t time.Time) error {
+	return nil
+}
+
+var _ = Describe("Test", func() {
+	var (
+		stub stubDbUpdater
+	)
+
+	Describe("LastUpdate", func() {
+		It("should return GetLastUpdate", func() {
+			stub = stubDbUpdater{result: validDate}
+			timeStamp, err := LastUpdate(stub)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(timeStamp).To(Equal(time.Date(2010, time.January, 1, 0, 0, 0, 0, time.UTC)))
+		})
+		It("should return error if GetLastUpdate fails", func() {
+			stub = stubDbUpdater{result: queryError}
+			_, err := LastUpdate(stub)
+			Expect(err).To(HaveOccurred())
+		})
+		It("should return default date if GetLastUpdate returns sql.ErrNoRows", func() {
+			stub = stubDbUpdater{result: noRows}
+			timeStamp, err := LastUpdate(stub)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(timeStamp).To(Equal(time.Date(2017, time.June, 11, 0, 0, 0, 0, time.UTC)))
+		})
+	})
+})

--- a/suite_test.go
+++ b/suite_test.go
@@ -1,0 +1,13 @@
+package npidb_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"testing"
+)
+
+func TestCommand(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Library Suite")
+}


### PR DESCRIPTION
Do not return an error when default value is returned from LastUpdate.

Add tests for LastUpdate.